### PR TITLE
Explicitly reference pipeline library in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,8 @@
+#!/usr/bin/groovy
+
+@Library('github.com/lachie83/jenkins-pipeline@master')
+def pipeline = new io.estrado.Pipeline()
+
 node {
   def goPath = "/go"
   def workDir = "${goPath}/src/github.com/lachie83/croc-hunter/"
@@ -19,27 +24,24 @@ node {
       return
   }
 
-  // load pipeline class
-  def pipeline = new io.estrado.Pipeline()
-
   // set additional git envvars for image tagging
   pipeline.gitEnvVars()
 
   // used to debug deployment setup
   env.DEBUG_DEPLOY = false
-  
+
   // debugging helm deployments
   if (env.DEBUG_DEPLOY == 'true') {
     println "Runing helm tests"
     pipeline.kubectlTest()
     pipeline.helmConfig()
-  }  
+  }
 
   def acct = pipeline.getContainerRepoAcct(config)
 
-  // tag image with version, and branch-commit_id  
+  // tag image with version, and branch-commit_id
   def image_tags_map = pipeline.getContainerTags(config)
-  
+
   // compile tag list
   def image_tags_list = pipeline.getMapValues(image_tags_map)
 


### PR DESCRIPTION
I had a lot of trouble getting Jenkins to fetch the https://github.com/lachie83/jenkins-pipeline library. Originally, I somehow got it working by either when configuring the Github Organization plugin or at the Jenkins system configuration level—when I tried again on a fresh jenkins chart install, no bueno. I'm sure there's some Jenkins configuration bit I'm not grokking, but in anycase, explicitly declaring the library in the `Jenkinsfile` appears to do the trick without issue.